### PR TITLE
Fix import path for local OrbitControls

### DIFF
--- a/towergame/libs/OrbitControls.js
+++ b/towergame/libs/OrbitControls.js
@@ -1,12 +1,12 @@
 import {
-	EventDispatcher,
-	MOUSE,
-	Quaternion,
-	Spherical,
-	TOUCH,
-	Vector2,
-	Vector3
-} from 'three';
+        EventDispatcher,
+        MOUSE,
+        Quaternion,
+        Spherical,
+        TOUCH,
+        Vector2,
+        Vector3
+} from './three.module.min.js';
 
 // OrbitControls performs orbiting, dollying (zooming), and panning.
 // Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).


### PR DESCRIPTION
## Summary
- fix module path in `libs/OrbitControls.js` so the module works without a bundler

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684161818e98832d8a4d7124cb08cecf