### PR TITLE
Fix missing index for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Tower Game
+
+This repository contains a simple browser-based tower stacking game.
+
+## Running locally
+
+Because the project uses ES modules, you'll need to serve the files over HTTP.
+Run a quick server from the repository root:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open [http://localhost:8000/towergame/index.html](http://localhost:8000/towergame/index.html) in your browser.
+
+The repository root also contains a small `index.html` that simply redirects
+to the game directory. This makes GitHub Pages and other static hosting services
+load the game automatically at the project root URL.
+
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=towergame/index.html">
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p>Redirecting to <a href="towergame/index.html">towergame/index.html</a>...</p>
+</body>
+</html>

--- a/towergame/index.html
+++ b/towergame/index.html
@@ -57,7 +57,7 @@
   </div>
   
   <!-- 主要遊戲腳本 -->
-  <script type="module" src="main.js"></script>
+  <script type="module" src="./main.js"></script>
   
   <!-- 錯誤處理 -->
   <script>

--- a/towergame/libs/OrbitControls.js
+++ b/towergame/libs/OrbitControls.js
@@ -1,12 +1,12 @@
 import {
-	EventDispatcher,
-	MOUSE,
-	Quaternion,
-	Spherical,
-	TOUCH,
-	Vector2,
-	Vector3
-} from 'three';
+        EventDispatcher,
+        MOUSE,
+        Quaternion,
+        Spherical,
+        TOUCH,
+        Vector2,
+        Vector3
+} from './three.module.min.js';
 
 // OrbitControls performs orbiting, dollying (zooming), and panning.
 // Unlike TrackballControls, it maintains the "up" direction object.up (+Y by default).


### PR DESCRIPTION
## Summary
- add a root `index.html` that redirects to the game directory
- document the redirect behavior in the README

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684161818e98832d8a4d7124cb08cecf