### PR TITLE
Fix block alignment and preload settings

### DIFF
--- a/towergame/index.html
+++ b/towergame/index.html
@@ -17,9 +17,9 @@
   <link rel="stylesheet" href="style.css">
   
   <!-- 預載入重要資源 -->
-  <link rel="preload" href="./libs/three.module.min.js" as="script">
-  <link rel="preload" href="./libs/cannon-es.js" as="script">
-  <link rel="preload" href="./assets/wood.jpg" as="image">
+  <link rel="preload" href="./libs/three.module.min.js" as="script" crossorigin="anonymous">
+  <link rel="preload" href="./libs/cannon-es.js" as="script" crossorigin="anonymous">
+  <link rel="preload" href="./assets/wood.jpg" as="image" crossorigin="anonymous">
   
   <!-- Favicon (可選) -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🎯</text></svg>">

--- a/towergame/main.js
+++ b/towergame/main.js
@@ -251,11 +251,13 @@ class JengaGame {
   calculateBlockPosition(layer, index, y) {
     const isEvenLayer = layer % 2 === 0;
     const offset = (index - 1) * (CONFIG.BLOCK_SIZE.z + CONFIG.BLOCK_GAP);
-    
+
+    // 偶數層的積木長邊朝 X 軸，需沿著 Z 軸排列
+    // 奇數層的積木長邊朝 Z 軸，需沿著 X 軸排列
     return new THREE.Vector3(
-      isEvenLayer ? offset : 0,
+      isEvenLayer ? 0 : offset,
       y,
-      isEvenLayer ? 0 : offset
+      isEvenLayer ? offset : 0
     );
   }
 


### PR DESCRIPTION
## Summary
- add `crossorigin="anonymous"` on preload links for script and texture files
- correct block arrangement logic so each layer stacks along its center

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684244bec734832d8519cf66c393f278