### PR TITLE
Fix tower stability and UI layout

### DIFF
--- a/towergame/index.html
+++ b/towergame/index.html
@@ -17,9 +17,9 @@
   <link rel="stylesheet" href="style.css">
   
   <!-- 預載入重要資源 -->
-  <link rel="preload" href="./libs/three.module.min.js" as="script">
-  <link rel="preload" href="./libs/cannon-es.js" as="script">
-  <link rel="preload" href="./assets/wood.jpg" as="image">
+  <link rel="preload" href="./libs/three.module.min.js" as="script" crossorigin="anonymous">
+  <link rel="preload" href="./libs/cannon-es.js" as="script" crossorigin="anonymous">
+  <link rel="preload" href="./assets/wood.jpg" as="image" crossorigin="anonymous">
   
   <!-- Favicon (可選) -->
   <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🎯</text></svg>">

--- a/towergame/main.js
+++ b/towergame/main.js
@@ -246,16 +246,26 @@ class JengaGame {
       
       y += CONFIG.BLOCK_SIZE.y + CONFIG.BLOCK_GAP;
     }
+
+    // 生成後啟用動態物理並讓積木保持休眠狀態
+    this.blocks.forEach(block => {
+      block.body.mass = 1;
+      block.body.type = CANNON.Body.DYNAMIC;
+      block.body.updateMassProperties();
+      block.body.sleep();
+    });
   }
 
   calculateBlockPosition(layer, index, y) {
     const isEvenLayer = layer % 2 === 0;
     const offset = (index - 1) * (CONFIG.BLOCK_SIZE.z + CONFIG.BLOCK_GAP);
-    
+
+    // 偶數層的積木長邊朝 X 軸，需沿著 Z 軸排列
+    // 奇數層的積木長邊朝 Z 軸，需沿著 X 軸排列
     return new THREE.Vector3(
-      isEvenLayer ? offset : 0,
+      isEvenLayer ? 0 : offset,
       y,
-      isEvenLayer ? 0 : offset
+      isEvenLayer ? offset : 0
     );
   }
 
@@ -293,7 +303,7 @@ class JengaGame {
     ));
     
     const body = new CANNON.Body({
-      mass: 1,
+      mass: 0,
       shape: shape,
       position: new CANNON.Vec3(position.x, position.y, position.z),
       sleepSpeedLimit: 0.1,

--- a/towergame/style.css
+++ b/towergame/style.css
@@ -64,8 +64,8 @@ body::before {
 #info {
   position: absolute;
   top: 30px;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 30px;
+  transform: none;
   background: var(--glass-bg);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -220,9 +220,11 @@ body::before {
 @media (max-width: 768px) {
   #info {
     top: 20px;
+    left: 20px;
+    transform: none;
     padding: 16px 24px;
     min-width: 280px;
-    width: 90%;
+    width: auto;
     max-width: 400px;
   }
   
@@ -244,11 +246,11 @@ body::before {
 @keyframes slideDown {
   from {
     opacity: 0;
-    transform: translateX(-50%) translateY(-20px);
+    transform: translateY(-20px);
   }
   to {
     opacity: 1;
-    transform: translateX(-50%) translateY(0);
+    transform: translateY(0);
   }
 }
 


### PR DESCRIPTION
## Summary
- keep the initial tower static until after it is built to avoid collapsing
- move info panel to the left of the screen
- adjust `slideDown` animation for the new layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684244bec734832d8519cf66c393f278